### PR TITLE
CambiandoUserPorClientEnIngresos

### DIFF
--- a/src/main/java/una/force_gym/controller/ClientController.java
+++ b/src/main/java/una/force_gym/controller/ClientController.java
@@ -113,6 +113,7 @@ public class ClientController {
 
             clientDTO.getIdUser(),
             clientDTO.getRegistrationDate(),
+            clientDTO.getExpirationMembershipDate(),
             clientDTO.getEmergencyContact(),
             clientDTO.getSignatureImage(),
             clientDTO.getParamLoggedIdUser()
@@ -157,6 +158,7 @@ public class ClientController {
 
             clientDTO.getIdUser(),
             clientDTO.getRegistrationDate(),
+            clientDTO.getExpirationMembershipDate(),
             clientDTO.getEmergencyContact(),
             clientDTO.getSignatureImage(),
             clientDTO.getIsDeleted(),

--- a/src/main/java/una/force_gym/controller/EconomicIncomeController.java
+++ b/src/main/java/una/force_gym/controller/EconomicIncomeController.java
@@ -60,7 +60,7 @@ public class EconomicIncomeController {
     @PostMapping("/add")
     public ResponseEntity<ApiResponse<String>> addEconomicIncome(@RequestBody EconomicIncomeDTO economicIncomeDTO) {
         int result = economicIncomeService.addEconomicIncome(
-            economicIncomeDTO.getIdUser(), 
+            economicIncomeDTO.getIdClient(), 
             economicIncomeDTO.getRegistrationDate(), 
             economicIncomeDTO.getVoucherNumber(), 
             economicIncomeDTO.getDetail(), 
@@ -92,7 +92,7 @@ public class EconomicIncomeController {
     public ResponseEntity<ApiResponse<String>> updateEconomicIncome(@RequestBody EconomicIncomeDTO economicIncomeDTO) {
         int result = economicIncomeService.updateEconomicIncome(
             economicIncomeDTO.getIdEconomicIncome(), 
-            economicIncomeDTO.getIdUser(), 
+            economicIncomeDTO.getIdClient(), 
             economicIncomeDTO.getRegistrationDate(), 
             economicIncomeDTO.getVoucherNumber(), 
             economicIncomeDTO.getDetail(), 

--- a/src/main/java/una/force_gym/domain/Client.java
+++ b/src/main/java/una/force_gym/domain/Client.java
@@ -37,6 +37,9 @@ public class Client {
     @Column(name = "registrationDate")
     private Date registrationDate;
 
+    @Column(name = "expirationMembershipDate")
+    private Date expirationMembershipDate;
+
     @Column(name = "emergencyContact")
     private String emergencyContact;
 
@@ -49,13 +52,14 @@ public class Client {
     public Client() {}
 
     public Client(Long idClient, Person person, TypeClient typeClient, HealthQuestionnaire healthQuestionnaire,
-                  User user, Date registrationDate, String emergencyContact, String signatureImage, Long isDeleted) {
+                  User user, Date registrationDate, Date expirationMembershipDate, String emergencyContact, String signatureImage, Long isDeleted) {
         this.idClient = idClient;
         this.person = person;
         this.typeClient = typeClient;
         this.healthQuestionnaire = healthQuestionnaire;
         this.user = user;
         this.registrationDate = registrationDate;
+        this.expirationMembershipDate = expirationMembershipDate;
         this.emergencyContact = emergencyContact;
         this.signatureImage = signatureImage;
         this.isDeleted = isDeleted;
@@ -107,6 +111,14 @@ public class Client {
 
     public void setRegistrationDate(Date registrationDate) {
         this.registrationDate = registrationDate;
+    }
+
+    public Date getExpirationMembershipDate() {
+        return expirationMembershipDate;
+    }
+
+    public void setExpirationMembershipDate(Date expirationMembershipDate) {
+        this.expirationMembershipDate = expirationMembershipDate;
     }
 
     public String getEmergencyContact() {

--- a/src/main/java/una/force_gym/domain/EconomicIncome.java
+++ b/src/main/java/una/force_gym/domain/EconomicIncome.java
@@ -19,8 +19,8 @@ public class EconomicIncome {
     private Long idEconomicIncome;
 
     @ManyToOne(fetch = FetchType.EAGER)
-    @JoinColumn(name = "idUser", referencedColumnName = "idUser")
-    private User user;
+    @JoinColumn(name = "idClient", referencedColumnName = "idClient")
+    private Client client;
 
     @Column(name = "registrationDate")
     private LocalDate registrationDate;
@@ -47,9 +47,9 @@ public class EconomicIncome {
 
     public EconomicIncome() {}
 
-    public EconomicIncome(Long idEconomicIncome, User user, LocalDate registrationDate, String voucherNumber, String detail, MeanOfPayment meanOfPayment, Float amount, ActivityType activityType, Long isDeleted) {
+    public EconomicIncome(Long idEconomicIncome, Client client, LocalDate registrationDate, String voucherNumber, String detail, MeanOfPayment meanOfPayment, Float amount, ActivityType activityType, Long isDeleted) {
         this.idEconomicIncome = idEconomicIncome;
-        this.user = user;
+        this.client = client;
         this.registrationDate = registrationDate;
         this.voucherNumber = voucherNumber;
         this.detail = detail;
@@ -67,12 +67,12 @@ public class EconomicIncome {
         this.idEconomicIncome = idEconomicIncome;
     }
 
-    public User getUser() {
-        return user;
+    public Client getClient() {
+        return client;
     }
 
-    public void setUser(User user) {
-        this.user = user;
+    public void setClient(Client client) {
+        this.client = client;
     }
 
     public LocalDate getRegistrationDate() {

--- a/src/main/java/una/force_gym/dto/ClientDTO.java
+++ b/src/main/java/una/force_gym/dto/ClientDTO.java
@@ -33,6 +33,7 @@ public class ClientDTO {
 
     private Long idUser;
     private Date registrationDate;
+    private Date expirationMembershipDate;
     private String emergencyContact;
     private String signatureImage;
     private Long isDeleted;
@@ -44,7 +45,7 @@ public class ClientDTO {
             LocalDate birthday, String identificationNumber, String phoneNumber, String email, Long idGender,
             Long idTypeClient, Long idHealthQuestionnaire, Boolean diabetes, Boolean hypertension,
             Boolean muscleInjuries, Boolean boneJointIssues, Boolean balanceLoss, Boolean cardiovascularDisease,
-            Boolean breathingIssues, Long idUser, Date registrationDate, String emergencyContact, String signatureImage,
+            Boolean breathingIssues, Long idUser, Date registrationDate, Date expirationMembershipDate, String emergencyContact, String signatureImage,
             Long isDeleted, Long paramLoggedIdUser) {
         this.idClient = idClient;
         this.idPerson = idPerson;
@@ -67,6 +68,7 @@ public class ClientDTO {
         this.breathingIssues = breathingIssues;
         this.idUser = idUser;
         this.registrationDate = registrationDate;
+        this.expirationMembershipDate = expirationMembershipDate;
         this.emergencyContact = emergencyContact;
         this.signatureImage = signatureImage;
         this.isDeleted = isDeleted;
@@ -239,6 +241,14 @@ public class ClientDTO {
 
     public void setRegistrationDate(Date registrationDate) {
         this.registrationDate = registrationDate;
+    }
+
+    public Date getExpirationMembershipDate() {
+        return expirationMembershipDate;
+    }
+
+    public void setExpirationMembershipDate(Date expirationMembershipDate) {
+        this.expirationMembershipDate = expirationMembershipDate;
     }
 
     public String getEmergencyContact() {

--- a/src/main/java/una/force_gym/dto/EconomicIncomeDTO.java
+++ b/src/main/java/una/force_gym/dto/EconomicIncomeDTO.java
@@ -5,7 +5,7 @@ import java.time.LocalDate;
 public class EconomicIncomeDTO {
 
     private Long idEconomicIncome;
-    private Long idUser;
+    private Long idClient;
     private LocalDate registrationDate;
     private String voucherNumber;
     private String detail;
@@ -17,11 +17,11 @@ public class EconomicIncomeDTO {
 
     public EconomicIncomeDTO() {}
 
-    public EconomicIncomeDTO(Long idEconomicIncome, Long idUser, LocalDate registrationDate, String voucherNumber,
+    public EconomicIncomeDTO(Long idEconomicIncome, Long idClient, LocalDate registrationDate, String voucherNumber,
             String detail, Long idMeanOfPayment, Float amount, Long idActivityType, Long isDeleted,
             Long paramLoggedIdUser) {
         this.idEconomicIncome = idEconomicIncome;
-        this.idUser = idUser;
+        this.idClient = idClient;
         this.registrationDate = registrationDate;
         this.voucherNumber = voucherNumber;
         this.detail = detail;
@@ -40,12 +40,12 @@ public class EconomicIncomeDTO {
         this.idEconomicIncome = idEconomicIncome;
     }
 
-    public Long getIdUser() {
-        return idUser;
+    public Long getIdClient() {
+        return idClient;
     }
 
-    public void setIdUser(Long idUser) {
-        this.idUser = idUser;
+    public void setIdClient(Long idClient) {
+        this.idClient = idClient;
     }
 
     public LocalDate getRegistrationDate() {

--- a/src/main/java/una/force_gym/repository/ClientRepository.java
+++ b/src/main/java/una/force_gym/repository/ClientRepository.java
@@ -36,6 +36,7 @@ public interface ClientRepository extends JpaRepository<Client, Long> {
 
         @Param("pIdUser") Long pIdUser, 
         @Param("pRegistrationDate") Date registrationDate, 
+        @Param("pExpirationMembershipDate") Date pExpirationMembershipDate, 
         @Param("pEmergencyContact") String pEmergencyContact, 
         @Param("pSignatureImage") String pSignatureImage, 
         @Param("pLoggedIdUser") Long pLoggedIdUser
@@ -70,6 +71,7 @@ public interface ClientRepository extends JpaRepository<Client, Long> {
 
         @Param("pIdUser") Long pIdUser, 
         @Param("pRegistrationDate") Date registrationDate, 
+        @Param("pExpirationMembershipDate") Date pExpirationMembershipDate, 
         @Param("pEmergencyContact") String pEmergencyContact, 
         @Param("pSignatureImage") String pSignatureImage, 
         @Param("pIsDeleted") Long pIsDeleted,  

--- a/src/main/java/una/force_gym/repository/EconomicIncomeRepository.java
+++ b/src/main/java/una/force_gym/repository/EconomicIncomeRepository.java
@@ -11,10 +11,10 @@ import una.force_gym.domain.EconomicIncome;
 public interface EconomicIncomeRepository extends JpaRepository<EconomicIncome, Long>{
 
     @Procedure(procedureName = "prInsertEconomicIncome", outputParameterName = "result")
-    int addEconomicIncome(@Param("pIdUser") Long pIdUser, @Param("pRegistrationDate") LocalDate pRegistrationDate, @Param("pVoucherNumber") String pVoucherNumber, @Param("pDetail") String pDetail, @Param("pIdMeanOfPayment") Long pIdMeanOfPayment, @Param("pAmount") Float pAmount, @Param("pIdActivityType") Long pIdActivityType, @Param("pLoggedIdUser") Long pLoggedIdUser);
+    int addEconomicIncome(@Param("pIdClient") Long pIdClient, @Param("pRegistrationDate") LocalDate pRegistrationDate, @Param("pVoucherNumber") String pVoucherNumber, @Param("pDetail") String pDetail, @Param("pIdMeanOfPayment") Long pIdMeanOfPayment, @Param("pAmount") Float pAmount, @Param("pIdActivityType") Long pIdActivityType, @Param("pLoggedIdUser") Long pLoggedIdUser);
 
     @Procedure(procedureName = "prUpdateEconomicIncome", outputParameterName = "result")
-    int updateEconomicIncome(@Param("pIdEconomicIncome") Long pIdEconomicIncome, @Param("pIdUser") Long pIdUser, @Param("pRegistrationDate") LocalDate pRegistrationDate, @Param("pVoucherNumber") String pVoucherNumber, @Param("pDetail") String pDetail, @Param("pIdMeanOfPayment") Long pIdMeanOfPayment, @Param("pAmount") Float pAmount, @Param("pIdActivityType") Long pIdActivityType, @Param("pIsDeleted") Long pIsDeleted,  @Param("pLoggedIdUser") Long pLoggedIdUser);
+    int updateEconomicIncome(@Param("pIdEconomicIncome") Long pIdEconomicIncome, @Param("pIdClient") Long pIdClient, @Param("pRegistrationDate") LocalDate pRegistrationDate, @Param("pVoucherNumber") String pVoucherNumber, @Param("pDetail") String pDetail, @Param("pIdMeanOfPayment") Long pIdMeanOfPayment, @Param("pAmount") Float pAmount, @Param("pIdActivityType") Long pIdActivityType, @Param("pIsDeleted") Long pIsDeleted,  @Param("pLoggedIdUser") Long pLoggedIdUser);
 
     @Procedure(procedureName = "prDeleteEconomicIncome")
     int deleteEconomicIncome(@Param("pIdEconomicIncome") Long pIdEconomicIncome, @Param("pLoggedIdUser") Long pLoggedIdUser);

--- a/src/main/java/una/force_gym/service/ClientService.java
+++ b/src/main/java/una/force_gym/service/ClientService.java
@@ -142,6 +142,7 @@ public class ClientService {
 
                         Long pIdUser,
                         Date pRegistrationDate, 
+                        Date pExpirationMembershipDate,
                         String pEmergencyContact, 
                         String pSignatureImage, 
                         Long pLoggedIdUser) {
@@ -164,6 +165,7 @@ public class ClientService {
                                     pBreathingIssues, 
                                     pIdUser, 
                                     pRegistrationDate, 
+                                    pExpirationMembershipDate,
                                     pEmergencyContact, 
                                     pSignatureImage, 
                                     pLoggedIdUser);
@@ -194,6 +196,7 @@ public class ClientService {
 
                             Long pIdUser,
                             Date pRegistrationDate, 
+                            Date pExpirationMembershipDate,
                             String pEmergencyContact, 
                             String pSignatureImage,
                             Long pIsDeleted, 
@@ -219,6 +222,7 @@ public class ClientService {
                                         pBreathingIssues, 
                                         pIdUser, 
                                         pRegistrationDate, 
+                                        pExpirationMembershipDate,
                                         pEmergencyContact, 
                                         pSignatureImage, 
                                         pIsDeleted,

--- a/src/main/java/una/force_gym/service/EconomicIncomeService.java
+++ b/src/main/java/una/force_gym/service/EconomicIncomeService.java
@@ -94,13 +94,13 @@ public class EconomicIncomeService {
     }
 
     @Transactional
-    public int addEconomicIncome(Long pIdUser, LocalDate pRegistrationDate, String pVoucherNumber, String pDetail, Long pIdMeanOfPayment, Float pAmount, Long pIdActivityType, Long pLoggedIdUser){
-        return economicIncomeRepo.addEconomicIncome(pIdUser, pRegistrationDate, pVoucherNumber, pDetail, pIdMeanOfPayment, pAmount, pIdActivityType, pLoggedIdUser);
+    public int addEconomicIncome(Long pIdClient, LocalDate pRegistrationDate, String pVoucherNumber, String pDetail, Long pIdMeanOfPayment, Float pAmount, Long pIdActivityType, Long pLoggedIdUser){
+        return economicIncomeRepo.addEconomicIncome(pIdClient, pRegistrationDate, pVoucherNumber, pDetail, pIdMeanOfPayment, pAmount, pIdActivityType, pLoggedIdUser);
     }
 
     @Transactional
-    public int updateEconomicIncome(Long pIdEconomicIncome, Long pIdUser, LocalDate pRegistrationDate, String pVoucherNumber, String pDetail, Long pIdMeanOfPayment, Float pAmount, Long pIdActivityType, Long pIsDeleted, Long pLoggedIdUser){
-        return economicIncomeRepo.updateEconomicIncome(pIdEconomicIncome, pIdUser, pRegistrationDate, pVoucherNumber, pDetail, pIdMeanOfPayment, pAmount, pIdActivityType, pIsDeleted, pLoggedIdUser);
+    public int updateEconomicIncome(Long pIdEconomicIncome, Long pIdClient, LocalDate pRegistrationDate, String pVoucherNumber, String pDetail, Long pIdMeanOfPayment, Float pAmount, Long pIdActivityType, Long pIsDeleted, Long pLoggedIdUser){
+        return economicIncomeRepo.updateEconomicIncome(pIdEconomicIncome, pIdClient, pRegistrationDate, pVoucherNumber, pDetail, pIdMeanOfPayment, pAmount, pIdActivityType, pIsDeleted, pLoggedIdUser);
     }
 
     @Transactional


### PR DESCRIPTION
Debido a que Ingresos solo son concebidos por pagos de membresía, se cambia para que tengan el Client que está pagando y darle seguimiento a los vencimientos y demás