### PR TITLE
[13/03 16:50h] Endpoint para filtrar plantillas por tipo de notificacion

### DIFF
--- a/src/main/java/una/force_gym/controller/NotificationTemplateController.java
+++ b/src/main/java/una/force_gym/controller/NotificationTemplateController.java
@@ -36,10 +36,11 @@ public class NotificationTemplateController {
             @RequestParam(defaultValue = "") String searchTerm,
             @RequestParam(defaultValue = "") String orderBy,
             @RequestParam(defaultValue = "") String directionOrderBy,
-            @RequestParam(defaultValue = "") String filterByStatus
+            @RequestParam(defaultValue = "") String filterByStatus,
+            @RequestParam(defaultValue = "-1") int filterByNotificationType
             )  {
         try {
-            Map<String, Object> responseData = notificationTemplateService.getNotificationTemplates(page, size, searchType, searchTerm, orderBy, directionOrderBy, filterByStatus);
+            Map<String, Object> responseData = notificationTemplateService.getNotificationTemplates(page, size, searchType, searchTerm, orderBy, directionOrderBy, filterByStatus, filterByNotificationType);
             ApiResponse<Map<String, Object>> response = new ApiResponse<>("Plantillas de notificación obtenidas correctamente.", responseData);
             return new ResponseEntity<>(response, HttpStatus.OK); 
 

--- a/src/main/java/una/force_gym/service/NotificationTemplateService.java
+++ b/src/main/java/una/force_gym/service/NotificationTemplateService.java
@@ -32,7 +32,8 @@ public class NotificationTemplateService {
         String searchTerm, 
         String orderBy, 
         String directionOrderBy, 
-        String filterByStatus
+        String filterByStatus,
+        int filterByNotificationType
     ) {
             
         StoredProcedureQuery query = entityManager.createStoredProcedureQuery("prGetNotificationTemplate", NotificationTemplate.class);
@@ -45,6 +46,7 @@ public class NotificationTemplateService {
         query.registerStoredProcedureParameter("p_orderBy", String.class, ParameterMode.IN);
         query.registerStoredProcedureParameter("p_directionOrderBy", String.class, ParameterMode.IN);
         query.registerStoredProcedureParameter("p_filterByStatus", String.class, ParameterMode.IN);
+        query.registerStoredProcedureParameter("p_filterByNotificationType", Integer.class, ParameterMode.IN);
 
         // Parámetro de salida
         query.registerStoredProcedureParameter("p_totalRecords", Integer.class, ParameterMode.OUT);
@@ -57,6 +59,7 @@ public class NotificationTemplateService {
         query.setParameter("p_orderBy", orderBy);
         query.setParameter("p_directionOrderBy", directionOrderBy);
         query.setParameter("p_filterByStatus", filterByStatus);
+        query.setParameter("p_filterByNotificationType", filterByNotificationType);
 
         // Ejecutar procedimiento
         query.execute();


### PR DESCRIPTION
Ahora se puede filtrar plantillas de notificación por el tipo de notificación.

Cambios realizados:
Agregar parámetro de notificationType al endpoint de Plantillas de Notificación.
Modificación del stored procedure para que pueda realizar la filtración de los datos en la consulta Select.