### PR TITLE
Fix - Historial de notificaciones desde la base de datos

### DIFF
--- a/src/main/java/una/force_gym/controller/NotificationController.java
+++ b/src/main/java/una/force_gym/controller/NotificationController.java
@@ -53,10 +53,8 @@ public class NotificationController {
     @PostMapping("/add")
     public ResponseEntity<ApiResponse<String>> addNotification(@RequestBody NotificationDTO notificationDTO) {
         int result = notificationService.addNotification(
-            notificationDTO.getIdUser(), 
-            notificationDTO.getIdNotificationTemplate(), 
-            notificationDTO.getSendDate(), 
-            notificationDTO.getParamLoggedIdUser()
+            notificationDTO.getIdClient(), 
+            notificationDTO.getIdNotificationType()
         );
 
         switch(result) {
@@ -81,11 +79,9 @@ public class NotificationController {
     public ResponseEntity<ApiResponse<String>> updateNotification(@RequestBody NotificationDTO notificationDTO) {
         int result = notificationService.updateNotification(
             notificationDTO.getIdNotification(), 
-            notificationDTO.getIdUser(), 
-            notificationDTO.getIdNotificationTemplate(), 
-            notificationDTO.getSendDate(), 
-            notificationDTO.getIsDeleted(),
-            notificationDTO.getParamLoggedIdUser()
+            notificationDTO.getIdClient(), 
+            notificationDTO.getIdNotificationType(),
+            notificationDTO.getIsDeleted()
         );
 
         switch(result) {
@@ -111,7 +107,7 @@ public class NotificationController {
 
     @DeleteMapping("/delete/{idNotification}")
     public ResponseEntity<ApiResponse<String>> deleteNotification(@PathVariable("idNotification") Long idNotification, @RequestBody ParamLoggedIdUserDTO paramLoggedIdUser) {
-        int result = notificationService.deleteNotification(idNotification, paramLoggedIdUser.getParamLoggedIdUser());
+        int result = notificationService.deleteNotification(idNotification);
        
         switch(result) {
             case 1 -> 

--- a/src/main/java/una/force_gym/domain/Notification.java
+++ b/src/main/java/una/force_gym/domain/Notification.java
@@ -18,12 +18,12 @@ public class Notification {
     private Long idNotification;
 
     @ManyToOne(fetch = FetchType.EAGER)
-    @JoinColumn(name = "idUser", referencedColumnName = "idUser")
-    private User user;
+    @JoinColumn(name = "idClient", referencedColumnName = "idClient")
+    private Client client;
 
     @ManyToOne(fetch = FetchType.EAGER)
-    @JoinColumn(name = "idNotificationTemplate", referencedColumnName = "idNotificationTemplate")
-    private NotificationTemplate notificationTemplate;
+    @JoinColumn(name = "idNotificationType", referencedColumnName = "idNotificationType")
+    private NotificationType notificationType;
 
     @Column(name = "sendDate")
     private Date sendDate;
@@ -33,10 +33,10 @@ public class Notification {
 
     public Notification() {}
 
-    public Notification(Long idNotification, User user, NotificationTemplate notificationTemplate, Date sendDate, Long isDeleted) {
+    public Notification(Long idNotification, Client client, NotificationType notificationType, Date sendDate, Long isDeleted) {
         this.idNotification = idNotification;
-        this.user = user;
-        this.notificationTemplate = notificationTemplate;
+        this.client = client;
+        this.notificationType = notificationType;
         this.sendDate = sendDate;
         this.isDeleted = isDeleted;
     }
@@ -49,20 +49,20 @@ public class Notification {
         this.idNotification = idNotification;
     }
 
-    public User getUser() {
-        return user;
+    public Client getClient() {
+        return client;
     }
 
-    public void setUser(User user) {
-        this.user = user;
+    public void setClient(Client client) {
+        this.client = client;
     }
 
-    public NotificationTemplate getNotificationTemplate() {
-        return notificationTemplate;
+    public NotificationType getNotificationType() {
+        return notificationType;
     }
 
-    public void setNotificationTemplate(NotificationTemplate notificationTemplate) {
-        this.notificationTemplate = notificationTemplate;
+    public void setNotificationType(NotificationType notificationType) {
+        this.notificationType = notificationType;
     }
 
     public Date getSendDate() {
@@ -80,4 +80,5 @@ public class Notification {
     public void setIsDeleted(Long isDeleted) {
         this.isDeleted = isDeleted;
     }   
+
 }

--- a/src/main/java/una/force_gym/dto/NotificationDTO.java
+++ b/src/main/java/una/force_gym/dto/NotificationDTO.java
@@ -5,19 +5,19 @@ import java.util.Date;
 public class NotificationDTO {
     
     private Long idNotification;
-    private Long idUser;
-    private Long idNotificationTemplate;
+    private Long idClient;
+    private Long idNotificationType;
     private Date sendDate;
     private Long isDeleted;
     private Long paramLoggedIdUser;
 
     public NotificationDTO() {}
 
-    public NotificationDTO(Long idNotification, Long idUser, Long idNotificationTemplate, Date sendDate, Long isDeleted,
+    public NotificationDTO(Long idNotification, Long idClient, Long idNotificationType, Date sendDate, Long isDeleted,
             Long paramLoggedIdUser) {
         this.idNotification = idNotification;
-        this.idUser = idUser;
-        this.idNotificationTemplate = idNotificationTemplate;
+        this.idClient = idClient;
+        this.idNotificationType = idNotificationType;
         this.sendDate = sendDate;
         this.isDeleted = isDeleted;
         this.paramLoggedIdUser = paramLoggedIdUser;
@@ -31,20 +31,20 @@ public class NotificationDTO {
         this.idNotification = idNotification;
     }
 
-    public Long getIdUser() {
-        return idUser;
+    public Long getIdClient() {
+        return idClient;
     }
 
-    public void setIdUser(Long idUser) {
-        this.idUser = idUser;
+    public void setIdClient(Long idClient) {
+        this.idClient = idClient;
     }
 
-    public Long getIdNotificationTemplate() {
-        return idNotificationTemplate;
+    public Long getIdNotificationType() {
+        return idNotificationType;
     }
 
-    public void setIdNotificationTemplate(Long idNotificationTemplate) {
-        this.idNotificationTemplate = idNotificationTemplate;
+    public void setIdNotificationType(Long idNotificationType) {
+        this.idNotificationType = idNotificationType;
     }
 
     public Date getSendDate() {

--- a/src/main/java/una/force_gym/repository/NotificationRepository.java
+++ b/src/main/java/una/force_gym/repository/NotificationRepository.java
@@ -4,31 +4,24 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.query.Procedure;
 import org.springframework.data.repository.query.Param;
 
-import java.util.Date;
-
 import una.force_gym.domain.Notification;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
     
     @Procedure(procedureName = "prInsertNotification", outputParameterName = "result")
     int addNotification(
-        @Param("pIdUser") Long pIdUser,
-        @Param("pIdNotificationTemplate") Long pIdNotificationTemplate,
-        @Param("pSendDate") Date pSendDate,
-        @Param("pLoggedIdUser") Long pLoggedIdUser
+        @Param("pIdClient") Long pIdClient,
+        @Param("pIdNotificationType") Long pIdNotificationType
     );
 
     @Procedure(procedureName = "prUpdateNotification", outputParameterName = "result")
     int updateNotification(
         @Param("pIdNotification") Long pIdNotification,
-        @Param("pIdUser") Long pIdUser,
-        @Param("pIdNotificationTemplate") Long pIdNotificationTemplate,
-        @Param("pSendDate") Date pSendDate,
-        @Param("pIsDeleted") Long pIsDeleted,  
-        @Param("pLoggedIdUser") Long pLoggedIdUser
+        @Param("pIdClient") Long pIdClient,
+        @Param("pIdNotificationTemplate") Long pIdNotificationType,
+        @Param("pIsDeleted") Long pIsDeleted
     );
 
     @Procedure(procedureName = "prDeleteNotification", outputParameterName = "result")
-    int deleteNotification(  @Param("pIdNotification") Long pIdNotification, 
-                                    @Param("pLoggedIdUser") Long pLoggedIdUser);
+    int deleteNotification(  @Param("pIdNotification") Long pIdNotification);
 }

--- a/src/main/java/una/force_gym/service/NotificationService.java
+++ b/src/main/java/una/force_gym/service/NotificationService.java
@@ -1,6 +1,5 @@
 package una.force_gym.service;
 
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -79,35 +78,17 @@ public class NotificationService {
     }
     
     @Transactional
-    public int addNotification( Long pIdUser, 
-                                Long pIdNotificationTemplate,
-                                Date pSendDate, 
-                                Long pLoggedIdUser) {
-        return notificationRepo.addNotification(pIdUser, 
-                                                pIdNotificationTemplate, 
-                                                pSendDate,
-                                                pLoggedIdUser);
+    public int addNotification( Long pIdClient, Long pIdNotificationType) {
+        return notificationRepo.addNotification(pIdClient, pIdNotificationType);
     }
 
     @Transactional
-    public int updateNotification(  Long pIdNotification, 
-                                    Long pIdUser, 
-                                    Long pIdNotificationTemplate,
-                                    Date pSendDate, 
-                                    Long pIsDeleted,
-                                    Long pLoggedIdUser) {
-        return notificationRepo.updateNotification( pIdNotification, 
-                                                    pIdUser,
-                                                    pIdNotificationTemplate, 
-                                                    pSendDate,
-                                                    pIsDeleted,
-                                                    pLoggedIdUser);
+    public int updateNotification( Long pIdNotification, Long pIdClient, Long pIdNotificationType, Long pIsDeleted) {
+        return notificationRepo.updateNotification(pIdNotification, pIdClient, pIdNotificationType, pIsDeleted);
     }
 
     @Transactional
-    public int deleteNotification(  Long pIdNotification, 
-                                            Long pLoggedIdUser){
-        return notificationRepo.deleteNotification( pIdNotification, 
-                                                                    pLoggedIdUser);
+    public int deleteNotification(Long pIdNotification){
+        return notificationRepo.deleteNotification( pIdNotification);
     }
 }


### PR DESCRIPTION
**Cambios realizados:**

- El stored procedure que filtra cliente según tipo de notificación (para saber a quiénes se les debe notificar) ahora lee también la tbNotification para descartar a quiénes ya fueron notificados por lo mismo hace menos de 7 días.
- Se modificó la tabla tbNotification por lo que el flujo de los datos fueron cambiados para que se adapte a la base de datos.