### PR TITLE
Feature / Validación al agregar o actualizar un activo

### DIFF
--- a/src/main/java/una/force_gym/controller/AssetController.java
+++ b/src/main/java/una/force_gym/controller/AssetController.java
@@ -17,8 +17,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.ModelAndView;
 
-import una.force_gym.dto.ParamLoggedIdUserDTO;
 import una.force_gym.dto.Asset;
+import una.force_gym.dto.ParamLoggedIdUserDTO;
 import una.force_gym.exception.AppException;
 import una.force_gym.service.AssetService;
 import una.force_gym.util.ApiResponse;
@@ -80,6 +80,9 @@ public class AssetController {
             
             // no se encuentra el idUser
             case -1 -> throw new AppException("No se pudo agregar el nuevo activo debido a que el usuario asociado no está registrado.", HttpStatus.INTERNAL_SERVER_ERROR);
+            
+            // activo menor a 115000
+            case -2 -> throw new AppException("No se pudo agregar el nuevo activo debido a que su costo unitario es menor a 115000.", HttpStatus.INTERNAL_SERVER_ERROR);
             
             default -> throw new AppException("Activo no agregado debido a problemas en la consulta.", HttpStatus.INTERNAL_SERVER_ERROR);
         }


### PR DESCRIPTION
Se agregó una validación para que no se registren activos menores a 115000

Criterios de aceptación: Validar monto mínimo en formulario

Nombre Caso de prueba: Validar monto mínimo de activos

Pasos:

Crear activo
Ingresar monto < ₡115,000
Guardar

Resultado esperado: Muestra error, no guarda