### PR TITLE
Fix/validacion-telefonos-unicos

### DIFF
--- a/src/main/java/una/force_gym/controller/ClientController.java
+++ b/src/main/java/una/force_gym/controller/ClientController.java
@@ -87,29 +87,29 @@ public class ClientController {
 
     }
 
-   @GetMapping("/listAll")
+    @GetMapping("/listAll")
     public ResponseEntity<ApiResponse<List<Map<String, Object>>>> getAllClients() {
         try {
             List<Client> clients = clientService.getAllClients();
             List<Map<String, Object>> responseData = new ArrayList<>();
-            
+
             for (Client client : clients) {
                 Map<String, Object> map = new HashMap<>();
                 map.put("value", client.getIdClient());
-                map.put("label", client.getPerson().getName() + " " + 
-                        client.getPerson().getFirstLastName() + " " + 
-                        client.getPerson().getSecondLastName());
+                map.put("label", client.getPerson().getName() + " "
+                        + client.getPerson().getFirstLastName() + " "
+                        + client.getPerson().getSecondLastName());
                 map.put("idClientType", client.getTypeClient().getIdTypeClient());
                 responseData.add(map);
             }
 
-            ApiResponse<List<Map<String, Object>>> response = 
-                    new ApiResponse<>("Clientes obtenidos correctamente.", responseData);
+            ApiResponse<List<Map<String, Object>>> response
+                    = new ApiResponse<>("Clientes obtenidos correctamente.", responseData);
             return new ResponseEntity<>(response, HttpStatus.OK);
 
         } catch (RuntimeException e) {
-            ApiResponse<List<Map<String, Object>>> response = 
-                    new ApiResponse<>("Ocurrió un error al solicitar los datos de los clientes.", null);
+            ApiResponse<List<Map<String, Object>>> response
+                    = new ApiResponse<>("Ocurrió un error al solicitar los datos de los clientes.", null);
             return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
@@ -165,6 +165,8 @@ public class ClientController {
             }
             case 0 ->
                 throw new AppException("Ocurrió un error al agregar el nuevo cliente.", HttpStatus.INTERNAL_SERVER_ERROR);
+            case -2 ->
+                throw new AppException("No se pudo actualizar el cliente el número de teléfono ya está en uso.", HttpStatus.INTERNAL_SERVER_ERROR);
             default ->
                 throw new AppException("Cliente no agregado debido a problemas en la consulta.", HttpStatus.INTERNAL_SERVER_ERROR);
         }
@@ -213,6 +215,8 @@ public class ClientController {
                 throw new AppException("Ocurrió un error al actualizar el cliente.", HttpStatus.INTERNAL_SERVER_ERROR);
             case -1 ->
                 throw new AppException("No se pudo actualizar el cliente porque no se encuentra el registro.", HttpStatus.INTERNAL_SERVER_ERROR);
+            case -4 ->
+                throw new AppException("No se pudo actualizar el cliente el número de teléfono ya está en uso.", HttpStatus.INTERNAL_SERVER_ERROR);
             default ->
                 throw new AppException("Cliente no actualizado debido a problemas en la consulta.", HttpStatus.INTERNAL_SERVER_ERROR);
         }

--- a/src/main/java/una/force_gym/controller/UserController.java
+++ b/src/main/java/una/force_gym/controller/UserController.java
@@ -29,7 +29,7 @@ public class UserController {
     private UserService userService;
 
     @GetMapping("/list")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> getUsers( 
+    public ResponseEntity<ApiResponse<Map<String, Object>>> getUsers(
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size,
             @RequestParam(defaultValue = "1") int searchType,
@@ -37,15 +37,15 @@ public class UserController {
             @RequestParam(defaultValue = "") String orderBy,
             @RequestParam(defaultValue = "") String directionOrderBy,
             @RequestParam(defaultValue = "") String filterByStatus,
-            @RequestParam(defaultValue = "") String filterByRole)  {
+            @RequestParam(defaultValue = "") String filterByRole) {
         try {
             Map<String, Object> responseData = userService.getUsers(page, size, searchType, searchTerm, orderBy, directionOrderBy, filterByStatus, filterByRole);
             ApiResponse<Map<String, Object>> response = new ApiResponse<>("Usuarios obtenidos correctamente.", responseData);
-            return new ResponseEntity<>(response, HttpStatus.OK); 
+            return new ResponseEntity<>(response, HttpStatus.OK);
 
         } catch (RuntimeException e) {
             ApiResponse<Map<String, Object>> response = new ApiResponse<>("Ocurrió un error al solicitar los datos de los usuarios", null);
-            return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR); 
+            return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
         }
 
     }
@@ -53,40 +53,47 @@ public class UserController {
     @PostMapping("/add")
     public ResponseEntity<ApiResponse<String>> addUser(@RequestBody UserFormDTO userForm) {
         int result = userService.addUser(
-            userForm.getIdRole(), 
-            userForm.getName(), 
-            userForm.getFirstLastName(), 
-            userForm.getSecondLastName(), 
-            userForm.getBirthday(), 
-            userForm.getIdentificationNumber(), 
-            userForm.getPhoneNumber(), 
-            userForm.getEmail(), 
-            userForm.getIdGender(), 
-            userForm.getUsername(), 
-            userForm.getPassword(), 
-            userForm.getParamLoggedIdUser()
+                userForm.getIdRole(),
+                userForm.getName(),
+                userForm.getFirstLastName(),
+                userForm.getSecondLastName(),
+                userForm.getBirthday(),
+                userForm.getIdentificationNumber(),
+                userForm.getPhoneNumber(),
+                userForm.getEmail(),
+                userForm.getIdGender(),
+                userForm.getUsername(),
+                userForm.getPassword(),
+                userForm.getParamLoggedIdUser()
         );
 
-        switch(result){
-            case 1 -> 
-            { 
+        switch (result) {
+            case 1 -> {
                 ApiResponse<String> response = new ApiResponse<>("Usuario agregado correctamente.", null);
-                return new ResponseEntity<>(response, HttpStatus.OK); 
+                return new ResponseEntity<>(response, HttpStatus.OK);
             }
 
             // error de mysql
-            case 0 -> throw new AppException("Ocurrió un error al agregar el nuevo usuario.", HttpStatus.INTERNAL_SERVER_ERROR);
-                
+            case 0 ->
+                throw new AppException("Ocurrió un error al agregar el nuevo usuario.", HttpStatus.INTERNAL_SERVER_ERROR);
+
             // se encontró un idPerson previo
-            case -1 -> throw new AppException("No se pudo agregar el nuevo usuario debido a que ya existe un usuario para la persona asociada.", HttpStatus.INTERNAL_SERVER_ERROR);
-            
+            case -1 ->
+                throw new AppException("No se pudo agregar el nuevo usuario debido a que ya existe un usuario para la persona asociada.", HttpStatus.INTERNAL_SERVER_ERROR);
+
             // no se encuentra el idRole
-            case -2 -> throw new AppException("No se pudo agregar el nuevo usuario debido a que el rol asociado no está registrado.", HttpStatus.INTERNAL_SERVER_ERROR);
-            
+            case -2 ->
+                throw new AppException("No se pudo agregar el nuevo usuario debido a que el rol asociado no está registrado.", HttpStatus.INTERNAL_SERVER_ERROR);
+
             // username duplicado
-            case -3 -> throw new AppException("No se pudo agregar el nuevo usuario debido a que el nombre de usuario ya existe.", HttpStatus.INTERNAL_SERVER_ERROR);
-            
-            default -> throw new AppException("Usuario no agregado debido a problemas en la consulta.", HttpStatus.INTERNAL_SERVER_ERROR);
+            case -3 ->
+                throw new AppException("No se pudo agregar el nuevo usuario debido a que el nombre de usuario ya existe.", HttpStatus.INTERNAL_SERVER_ERROR);
+
+            case -4 ->
+                throw new AppException("No se pudo actualizar el usuario el número de teléfono ya está en uso.", HttpStatus.INTERNAL_SERVER_ERROR);
+
+            default ->
+                throw new AppException("Usuario no agregado debido a problemas en la consulta.", HttpStatus.INTERNAL_SERVER_ERROR);
         }
 
     }
@@ -94,46 +101,54 @@ public class UserController {
     @PutMapping("/update")
     public ResponseEntity<ApiResponse<String>> updateUser(@RequestBody UserFormDTO userForm) {
         int result = userService.updateUser(
-            userForm.getIdUser(), 
-            userForm.getIdRole(), 
-            userForm.getIdPerson(), 
-            userForm.getName(), 
-            userForm.getFirstLastName(), 
-            userForm.getSecondLastName(), 
-            userForm.getBirthday(), 
-            userForm.getIdentificationNumber(), 
-            userForm.getPhoneNumber(), 
-            userForm.getEmail(), 
-            userForm.getIdGender(), 
-            userForm.getUsername(), 
-            userForm.getPassword(), 
-            userForm.getIsDeleted(),
-            userForm.getParamLoggedIdUser()
+                userForm.getIdUser(),
+                userForm.getIdRole(),
+                userForm.getIdPerson(),
+                userForm.getName(),
+                userForm.getFirstLastName(),
+                userForm.getSecondLastName(),
+                userForm.getBirthday(),
+                userForm.getIdentificationNumber(),
+                userForm.getPhoneNumber(),
+                userForm.getEmail(),
+                userForm.getIdGender(),
+                userForm.getUsername(),
+                userForm.getPassword(),
+                userForm.getIsDeleted(),
+                userForm.getParamLoggedIdUser()
         );
 
-        switch(result){
-            case 1 -> 
-            { 
+        switch (result) {
+            case 1 -> {
                 ApiResponse<String> response = new ApiResponse<>("Usuario actualizado correctamente.", null);
-                return new ResponseEntity<>(response, HttpStatus.OK); 
+                return new ResponseEntity<>(response, HttpStatus.OK);
             }
 
             // error de mysql
-            case 0 -> throw new AppException("Ocurrió un error al actualizar el usuario.", HttpStatus.INTERNAL_SERVER_ERROR);
+            case 0 ->
+                throw new AppException("Ocurrió un error al actualizar el usuario.", HttpStatus.INTERNAL_SERVER_ERROR);
 
             // no se encuentra el idUser
-            case -1 -> throw new AppException("No se pudo actualizar el usuario debido a que no se encuentra el registro.", HttpStatus.INTERNAL_SERVER_ERROR);
-            
+            case -1 ->
+                throw new AppException("No se pudo actualizar el usuario debido a que no se encuentra el registro.", HttpStatus.INTERNAL_SERVER_ERROR);
+
             // no se encuentra el idPerson
-            case -2 -> throw new AppException("No se pudo actualizar el usuario debido a que la persona asociada no está registrada.", HttpStatus.INTERNAL_SERVER_ERROR);
-            
+            case -2 ->
+                throw new AppException("No se pudo actualizar el usuario debido a que la persona asociada no está registrada.", HttpStatus.INTERNAL_SERVER_ERROR);
+
             // no se encuentra el idRole
-            case -3 -> throw new AppException("No se pudo actualizar el usuario debido a que el rol asociado no está registrado.", HttpStatus.INTERNAL_SERVER_ERROR);
+            case -3 ->
+                throw new AppException("No se pudo actualizar el usuario debido a que el rol asociado no está registrado.", HttpStatus.INTERNAL_SERVER_ERROR);
 
             // username duplicado
-            case -4 -> throw new AppException("No se pudo actualizar el usuario debido a que el nombre de usuario ya existe.", HttpStatus.INTERNAL_SERVER_ERROR);
+            case -4 ->
+                throw new AppException("No se pudo actualizar el usuario debido a que el nombre de usuario ya existe.", HttpStatus.INTERNAL_SERVER_ERROR);
 
-            default -> throw new AppException("Usuario no actualizado debido a problemas en la consulta.", HttpStatus.INTERNAL_SERVER_ERROR);
+            case -5 ->
+                throw new AppException("No se pudo actualizar el usuario el número de teléfono ya está en uso.", HttpStatus.INTERNAL_SERVER_ERROR);
+
+            default ->
+                throw new AppException("Usuario no actualizado debido a problemas en la consulta.", HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -141,20 +156,22 @@ public class UserController {
     public ResponseEntity<ApiResponse<String>> deleteUser(@PathVariable("idUser") Long idUser, @RequestBody ParamLoggedIdUserDTO paramLoggedIdUser) {
         int result = userService.deleteUser(idUser, paramLoggedIdUser.getParamLoggedIdUser());
 
-        switch(result){
-            case 1 -> 
-            { 
+        switch (result) {
+            case 1 -> {
                 ApiResponse<String> response = new ApiResponse<>("Usuario eliminado correctamente.", null);
-                return new ResponseEntity<>(response, HttpStatus.OK); 
+                return new ResponseEntity<>(response, HttpStatus.OK);
             }
-            
+
             // error de mysql
-            case 0 -> throw new AppException("Ocurrió un error al eliminar el usuario.", HttpStatus.INTERNAL_SERVER_ERROR);
+            case 0 ->
+                throw new AppException("Ocurrió un error al eliminar el usuario.", HttpStatus.INTERNAL_SERVER_ERROR);
 
             // no se encuentra el idUser
-            case -1 -> throw new AppException("No se pudo eliminar el usuario debido a que no se encuentra el registro.", HttpStatus.INTERNAL_SERVER_ERROR);
+            case -1 ->
+                throw new AppException("No se pudo eliminar el usuario debido a que no se encuentra el registro.", HttpStatus.INTERNAL_SERVER_ERROR);
 
-            default -> throw new AppException("Usuario no eliminado debido a problemas en la consulta.", HttpStatus.INTERNAL_SERVER_ERROR);
+            default ->
+                throw new AppException("Usuario no eliminado debido a problemas en la consulta.", HttpStatus.INTERNAL_SERVER_ERROR);
         }
 
     }


### PR DESCRIPTION
Cambios realizados:
- Modificada lógica en controllers de usuarios y clientes
- Actualizados stored procedures para validación
- Implementado mensaje de error claro
- Validación aplicada en creación y actualización

Criterios de aceptación:
✓ Bloquea guardado con teléfonos duplicados
✓ Muestra mensaje de error específico
✓ Funciona tanto para usuarios como clientes
✓ Validación en backend

Casos de prueba:
1. Nombre: Crear con teléfono duplicado
   Pasos:
   - Ingresar número existente
   - Intentar guardar
   Esperado: Muestra error "El número ya está registrado"

2. Nombre: Actualizar a teléfono existente
   Pasos:
   - Editar registro existente
   - Cambiar a número duplicado
   Esperado: Impide guardar cambios

3. Nombre: Teléfono único válido
   Pasos:
   - Ingresar número nuevo
   Esperado: Permite guardar normalmente