### PR TITLE
Fix/guardado-orden-categorias-rutinas

### DIFF
--- a/src/main/java/una/force_gym/domain/RoutineExercise.java
+++ b/src/main/java/una/force_gym/domain/RoutineExercise.java
@@ -35,6 +35,9 @@ public class RoutineExercise {
     @Column(name = "note")
     private String note;
 
+    @Column(name = "categoryOrder")
+    private Integer categoryOrder;
+
     public RoutineExercise() {
     }
 
@@ -45,6 +48,16 @@ public class RoutineExercise {
         this.routine = routine;
         this.series = series;
         this.note = note;
+    }
+
+    public RoutineExercise(Integer categoryOrder, Exercise exercise, Long idRoutineExercise, String note, Integer repetitions, Routine routine, Integer series) {
+        this.categoryOrder = categoryOrder;
+        this.exercise = exercise;
+        this.idRoutineExercise = idRoutineExercise;
+        this.note = note;
+        this.repetitions = repetitions;
+        this.routine = routine;
+        this.series = series;
     }
 
     public Long getIdRoutineExercise() {
@@ -90,8 +103,16 @@ public class RoutineExercise {
     public String getNote() {
         return note;
     }
-    
+
     public void setNote(String note) {
         this.note = note;
+    }
+
+    public Integer getCategoryOrder() {
+        return categoryOrder;
+    }
+
+    public void setCategoryOrder(Integer categoryOrder) {
+        this.categoryOrder = categoryOrder;
     }
 }

--- a/src/main/java/una/force_gym/dto/RoutineExerciseDTO.java
+++ b/src/main/java/una/force_gym/dto/RoutineExerciseDTO.java
@@ -1,12 +1,11 @@
 package una.force_gym.dto;
 
-import java.util.List;
-
 public class RoutineExerciseDTO {
 
     private Long idExercise;
     private Integer series;
     private Integer repetitions;
+    private Integer categoryOrder;
     private String note;
 
     public RoutineExerciseDTO() {
@@ -17,6 +16,14 @@ public class RoutineExerciseDTO {
         this.repetitions = repetitions;
         this.series = series;
         this.note = note;
+    }
+
+    public RoutineExerciseDTO(Integer categoryOrder, Long idExercise, String note, Integer repetitions, Integer series) {
+        this.categoryOrder = categoryOrder;
+        this.idExercise = idExercise;
+        this.note = note;
+        this.repetitions = repetitions;
+        this.series = series;
     }
 
     public Long getIdExercise() {
@@ -46,9 +53,17 @@ public class RoutineExerciseDTO {
     public String getNote() {
         return note;
     }
-    
+
     public void setNote(String note) {
         this.note = note;
+    }
+
+    public Integer getCategoryOrder() {
+        return categoryOrder;
+    }
+
+    public void setCategoryOrder(Integer categoryOrder) {
+        this.categoryOrder = categoryOrder;
     }
 
 }

--- a/src/main/java/una/force_gym/dto/RoutineWithExercisesDTO.java
+++ b/src/main/java/una/force_gym/dto/RoutineWithExercisesDTO.java
@@ -14,6 +14,7 @@ public class RoutineWithExercisesDTO {
     private DifficultyRoutine difficultyRoutine;
     private List<RoutineExerciseDTO> exercises;
     private List<RoutineAssignmentDTO> assignments;
+    private Integer categoryOrder;
     private Long isDeleted;
     private Long paramLoggedIdUser;
 
@@ -22,6 +23,19 @@ public class RoutineWithExercisesDTO {
 
     public RoutineWithExercisesDTO(List<RoutineAssignmentDTO> assignments, Date date, DifficultyRoutine difficultyRoutine, List<RoutineExerciseDTO> exercises, Long idRoutine, Long idUser, Long isDeleted, String name, Long paramLoggedIdUser) {
         this.assignments = assignments;
+        this.date = date;
+        this.difficultyRoutine = difficultyRoutine;
+        this.exercises = exercises;
+        this.idRoutine = idRoutine;
+        this.idUser = idUser;
+        this.isDeleted = isDeleted;
+        this.name = name;
+        this.paramLoggedIdUser = paramLoggedIdUser;
+    }
+
+    public RoutineWithExercisesDTO(List<RoutineAssignmentDTO> assignments, Integer categoryOrder, Date date, DifficultyRoutine difficultyRoutine, List<RoutineExerciseDTO> exercises, Long idRoutine, Long idUser, Long isDeleted, String name, Long paramLoggedIdUser) {
+        this.assignments = assignments;
+        this.categoryOrder = categoryOrder;
         this.date = date;
         this.difficultyRoutine = difficultyRoutine;
         this.exercises = exercises;
@@ -102,6 +116,14 @@ public class RoutineWithExercisesDTO {
 
     public void setParamLoggedIdUser(Long paramLoggedIdUser) {
         this.paramLoggedIdUser = paramLoggedIdUser;
+    }
+
+    public Integer getCategoryOrder() {
+        return categoryOrder;
+    }
+
+    public void setCategoryOrder(Integer categoryOrder) {
+        this.categoryOrder = categoryOrder;
     }
 
 }

--- a/src/main/java/una/force_gym/service/RoutineService.java
+++ b/src/main/java/una/force_gym/service/RoutineService.java
@@ -217,6 +217,7 @@ public class RoutineService {
                     routineExercise.setSeries(exDto.getSeries());
                     routineExercise.setRepetitions(exDto.getRepetitions());
                     routineExercise.setNote(exDto.getNote());
+                    routineExercise.setCategoryOrder(exDto.getCategoryOrder());
                     return routineExercise;
                 })
                 .collect(Collectors.toList());
@@ -279,6 +280,7 @@ public class RoutineService {
                     exDto.setSeries(ex.getSeries());
                     exDto.setRepetitions(ex.getRepetitions());
                     exDto.setNote(ex.getNote());
+                    exDto.setCategoryOrder(ex.getCategoryOrder());
                     return exDto;
                 })
                 .collect(Collectors.toList());


### PR DESCRIPTION
Cambios realizados:
- Añadido campo `categoryOrder` a tabla RutinaEjercicios
  - Actualizar orden
  - Obtener ejercicios ordenados

Criterios de aceptación:
✓ La BD acepta y persiste el orden
✓ Los endpoints devuelven ejercicios ordenados

Casos de prueba:
1. Nombre: Creación con orden
   Pasos:
   - Insertar nuevo ejercicio con orden
   - Consultar
   Esperado: Devuelve con orden correcto

2. Nombre: Actualización de orden
   Pasos:
   - Modificar orden existente
   - Consultar
   Esperado: Refleja nuevo orden